### PR TITLE
Aborting on Linux when saving the data

### DIFF
--- a/Functions/saveData.m
+++ b/Functions/saveData.m
@@ -59,7 +59,7 @@ folder = optionals{3};
 infoDicom = optionals{4};
 
 if(isempty(folder)) 
-    folder='Output';
+    folder='output';
 else
     mkdir([folder,filesep,title]);
 end


### PR DESCRIPTION
All output vars point to "output" dir, however, this one points to "Output", with capital "O". This, at least on Linux causes error when saving the data.